### PR TITLE
Update NumberFormatter.php

### DIFF
--- a/php/src/NumberFormatter.php
+++ b/php/src/NumberFormatter.php
@@ -1,5 +1,5 @@
 <?php
-
+// v1.0.4
 namespace NumberFormatter;
 
 class NumberFormatter
@@ -75,7 +75,7 @@ class NumberFormatter
     // Private methods... 
     private function isENotation($input)
     {
-        return preg_match('/^[-+]?[0-9]*\.?[0-9]+([eE][-+][0-9]+)$/', $input);
+        return preg_match('/^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)$/', $input);
     }
 
     private function format($input)
@@ -477,6 +477,9 @@ class NumberFormatter
     private function convertENotationToRegularNumber($eNotation)
     {
         // Conversion logic for E-notation to regular number
-        return number_format($eNotation, 10, '.', '');
+        $decimalNotation = sprintf('%.20f', $eNotation);
+        return $decimalNotation;
+        
+        //return number_format($eNotation, 10, '.', '');
     }
 }


### PR DESCRIPTION
In the function `convertENotationToRegularNumber`, if the numeric value passed to `number_format ` is very small, it returns 0. To solve the issue, `sprintf ` was used.