### PR TITLE
PR: Fix number formatting issues with trailing zeros and scientific notation

### DIFF
--- a/lib/format/index.js
+++ b/lib/format/index.js
@@ -64,7 +64,7 @@ class NumberFormatter {
     }
     // Private methods...
     isENotation(input) {
-        return /^[-+]?[0-9]*\.?[0-9]+([eE][-+][0-9]+)$/.test(input);
+        return /^[-+]?[0-9]*\.?[0-9]+([eE][-+]?[0-9]+)$/.test(input);
     }
     format(input) {
         let { precision, template } = this.options;
@@ -73,9 +73,14 @@ class NumberFormatter {
             return {};
         if (!(template === null || template === void 0 ? void 0 : template.match(/^(number|usd|irt|irr|percent)$/g)))
             template = 'number';
-        if (this.isENotation(input.toString())) {
+        
+        // Store original input string to preserve format for trailing zeros
+        const originalInput = input.toString();
+        
+        if (this.isENotation(originalInput)) {
             input = this.convertENotationToRegularNumber(Number(input));
         }
+        
         // Replace each Persian/Arabic numeral in the string with its English counterpart and strip all non-numeric chars
         let numberString = input
             .toString()
@@ -83,13 +88,15 @@ class NumberFormatter {
             return String(match.charCodeAt(0) & 0xf);
         })
             .replace(/[^\d.-]/g, '');
-        // Stripping leading zeros and trailing zeros after a decimal point
+        
+        // Stripping leading zeros only, preserve trailing zeros
         numberString = numberString
-            .replace(/^0+(?=\d)/g, '')
-            .replace(/(?<=\.\d*)0+$|(?<=\.\d)0+\b/g, '');
+            .replace(/^0+(?=\d)/g, '');
+        
         const number = Math.abs(Number(numberString));
         let p, d, r, c;
         let f = 0;
+        
         // Auto precision selection
         if (precision === 'auto') {
             if (template.match(/^(usd|irt|irr|number)$/g)) {
@@ -104,6 +111,7 @@ class NumberFormatter {
                 precision = 'low';
             }
         }
+        
         if (precision === 'medium') {
             if (number >= 0 && number < 0.0001) {
                 p = 33;
@@ -261,23 +269,89 @@ class NumberFormatter {
                 c = false;
             }
         }
-        return this.reducePrecision(numberString, p, d, r, c, f, template, language, outputFormat, prefixMarker, postfixMarker, prefix, postfix, thousandSeparator, decimalSeparator);
+        
+        // For scientific notation, increase precision to ensure correct representation
+        if (this.isENotation(originalInput)) {
+            p = Math.max(p, 20);
+            r = false;
+        }
+        
+        return this.reducePrecision(
+            numberString, 
+            p, 
+            d, 
+            r, 
+            c, 
+            f, 
+            template, 
+            language, 
+            outputFormat, 
+            prefixMarker, 
+            postfixMarker, 
+            prefix, 
+            postfix, 
+            thousandSeparator, 
+            decimalSeparator,
+            originalInput
+        );
     }
+    
     convertENotationToRegularNumber(eNotation) {
-        const [coefficientStr, exponentStr] = eNotation.toString().split('e');
-        const coefficientLength = coefficientStr
-            .replace('.', '')
-            .replace('-', '').length;
-        const exponent = parseFloat(exponentStr);
-        const precision = Math.max(coefficientLength - exponent, 1);
-        return eNotation.toFixed(precision);
+        // For simple cases like 1e3, directly use Number constructor
+        if (Number.isInteger(eNotation) && eNotation >= 1000) {
+            return eNotation.toString();
+        }
+        
+        const parts = eNotation.toString().toLowerCase().split('e');
+        if (parts.length !== 2) return eNotation.toString();
+        
+        const coefficient = parseFloat(parts[0]);
+        const exponent = parseInt(parts[1], 10);
+        
+        // Handle negative exponents (very small numbers)
+        if (exponent < 0) {
+            const absExponent = Math.abs(exponent);
+            // Determine precision needed to show all digits
+            const precision = absExponent + 
+                (parts[0].includes('.') ? parts[0].split('.')[1].length : 0);
+            return eNotation.toFixed(precision);
+        }
+        
+        // For positive exponents, let JavaScript do the conversion
+        return eNotation.toString();
     }
-    reducePrecision(numberString, precision = 30, nonZeroDigits = 4, round = false, compress = false, fixedDecimalZeros = 0, template = 'number', language = 'en', outputFormat = 'plain', prefixMarker = 'span', postfixMarker = 'span', prefix = '', postfix = '', thousandSeparator = ',', decimalSeparator = '.') {
+    
+    reducePrecision(
+        numberString, 
+        precision = 30, 
+        nonZeroDigits = 4, 
+        round = false, 
+        compress = false, 
+        fixedDecimalZeros = 0, 
+        template = 'number', 
+        language = 'en', 
+        outputFormat = 'plain', 
+        prefixMarker = 'span', 
+        postfixMarker = 'span', 
+        prefix = '', 
+        postfix = '', 
+        thousandSeparator = ',', 
+        decimalSeparator = '.',
+        originalInput = ''
+    ) {
         var _a, _b;
+        
         if (!numberString) {
             return {};
         }
+        
+        // Handle negative zero
+        if (numberString === '-0' || numberString === '-0.0') {
+            numberString = numberString.substring(1); // Remove negative sign for zero
+        }
+        
         numberString = numberString.toString();
+        
         const maxPrecision = 30;
         const maxIntegerDigits = 21;
         const scaleUnits = template.match(/^(number|percent)$/g)
@@ -407,9 +481,40 @@ class NumberFormatter {
                         ][parseInt(match, 10)];
                     });
         }
+        
         let fractionalPartStr = `${fractionalZeroStr}${fractionalNonZeroStr}`;
-        fractionalPartStr = fractionalPartStr.substring(0, precision);
-        fractionalPartStr = fractionalPartStr.replace(/^(\d*[1-9])0+$/g, '$1');
+        // Don't truncate trailing zeros when they're in the original string
+        if (fractionalPartStr.length > precision && !originalInput.includes('e')) {
+            fractionalPartStr = fractionalPartStr.substring(0, precision);
+        }
+        
+        // For scientific notation and numbers with trailing zeros, preserve the format
+        if (originalInput.includes('e') || originalInput.includes('E')) {
+            // For scientific notation, use the converted string
+        } else if (originalInput.includes('.')) {
+            // For regular numbers with decimal point, check for trailing zeros
+            const originalParts = originalInput.split('.');
+            if (originalParts.length === 2) {
+                const originalDecimal = originalParts[1];
+                // If original has more digits than what we have now, preserve those trailing zeros
+                if (originalDecimal.length > fractionalPartStr.length && originalDecimal.endsWith('0')) {
+                    // Count trailing zeros in original
+                    let trailingZeros = 0;
+                    for (let i = originalDecimal.length - 1; i >= 0; i--) {
+                        if (originalDecimal[i] === '0') {
+                            trailingZeros++;
+                        } else {
+                            break;
+                        }
+                    }
+                    // Add back trailing zeros if they were in the original
+                    if (trailingZeros > 0) {
+                        fractionalPartStr = fractionalPartStr.padEnd(fractionalPartStr.length + trailingZeros, '0');
+                    }
+                }
+            }
+        }
+        
         // Output Formating, Prefix, Postfix
         if (template === 'usd') {
             unitPrefix = language === 'en' ? '$' : '';
@@ -452,12 +557,17 @@ class NumberFormatter {
             : '';
         let out = '';
         let wholeNumberStr;
-        if (precision <= 0 || nonZeroDigits <= 0 || !fractionalNonZeroStr) {
+        
+        // FIXED: Changed condition to correctly handle numbers with trailing zeros
+        // Old condition: if (precision <= 0 || nonZeroDigits <= 0 || !fractionalNonZeroStr) {
+        // New condition checks if both fractional parts are empty
+        if (precision <= 0 || nonZeroDigits <= 0 || (fractionalNonZeroStr === '' && fractionalZeroStr === '')) {
             wholeNumberStr = `${nonFractionalStr.replace(thousandSeparatorRegex, ',')}${fixedDecimalZeroStr}`;
         }
         else {
             wholeNumberStr = `${nonFractionalStr.replace(thousandSeparatorRegex, ',')}.${fractionalPartStr}`;
         }
+        
         out = `${sign}${unitPrefix}${wholeNumberStr}${unitPostfix}`;
         const formattedObject = {
             value: out,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reduce-precision",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "",
   "main": "./ts/lib/index.js",
   "files": [


### PR DESCRIPTION
## Problem

The number formatter had several issues:

- Trailing zeros in decimal numbers were being incorrectly removed (e.g., `1.00` → `1`)
- Scientific notation was not properly handled (e.g., `1e3` was not converting to `1,000`)
- Negative zero (`-0`) was not normalized to `0`
- Some trailing zeros were inconsistently preserved in certain number formats

## Changes

This PR fixes these issues by:

### Trailing Zeros Preservation

- Removed the regex that was stripping trailing zeros after decimal points
- Modified how the fractional part is reconstructed to preserve original formatting
- Added tracking of the original input string to maintain trailing zeros

### Scientific Notation Handling

- Fixed the regex in `isENotation()` to correctly handle both positive and negative exponents
- Completely rewrote `convertENotationToRegularNumber()` to properly handle different cases
- Added special handling for integers and small decimal numbers in scientific notation

### Negative Zero Handling

- Added logic to normalize `-0` and `-0.0` to `0` and `0.0` respectively

### Other Improvements

- Modified the condition for including decimal parts to check if both fractional strings are empty
- Increased precision for scientific notation to ensure correct representation
- Added logic to count and preserve the exact number of trailing zeros from the original input
